### PR TITLE
feat: start a new express.js server at port 8000

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,13 @@
+const express = require('express')
+
+const app = express()
+
+const port = process.env.PORT || 8000
+
+app.get('/', (req, res) => {
+    res.send('Welcome to my API')
+})
+
+app.listen(port, () =>{
+    console.log('Server listening at port', port)
+})


### PR DESCRIPTION
Contains starting code for the server to run at port 8000. Can connect through localhost:8000. Use 'npm run dev'.